### PR TITLE
#1 SDK 27.0.2로 통일

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 27
     defaultConfig {
         applicationId "net.jspiner.mashup2"
         minSdkVersion 21
-        targetSdkVersion 26
+        targetSdkVersion 27
         multiDexEnabled true
         versionCode 1
         versionName "1.0"
@@ -28,7 +28,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'com.android.support:appcompat-v7:27.0.2'
     implementation 'com.android.support.constraint:constraint-layout:1.1.0'
     testImplementation('junit:junit:4.12', {
         exclude group: 'com.android.support', module: 'support-annotations'
@@ -44,10 +44,10 @@ dependencies {
     implementation 'com.facebook.android:facebook-login:[4,5)'
 
     // recyclerview
-    implementation 'com.android.support:recyclerview-v7:26.1.0'
+    implementation 'com.android.support:recyclerview-v7:27.0.2'
 
     // design support
-    implementation 'com.android.support:design:26.1.0'
+    implementation 'com.android.support:design:27.0.2'
 
     // network library
     implementation 'com.squareup.okhttp3:okhttp:3.10.0'


### PR DESCRIPTION
# 개요
facebook sdk내에서 vector-27.0.2를 사용중이라 26.x.x와 충돌나는 이슈 해결.

# 변경사항
- compile 버전 27로 변경
- support 버전 27.0.2로 변경